### PR TITLE
Add additional ontology entries

### DIFF
--- a/users.html
+++ b/users.html
@@ -767,6 +767,9 @@
 <li><a href="https://formative.jmir.org/2026/1/e82685/">Ontology of Medication Statements (OMS)</a></li>
 <li><a href="https://pubs.rsna.org/doi/10.1148/ryai.260070">Radiology Ontology of AI Datasets, Models and Projects (ROADMAP)</a></li>
 <li><a href="https://ojs.aaai.org/index.php/AAAI/article/download/40456/44417">Query-Efficient Domain Knowledge Stealing against LLMs</a></li>
+       <li><a href="https://arxiv.org/pdf/2604.01728">The AnIML Ontology</a></li>
+       <li><a href="https://arxiv.org/pdf/2606.08532">DN-Hypo-Pipeline Scientific Hypothesis Generation Framework</a></li>
+       <li><a href="https://link.springer.com/article/10.1186/s40594-026-00625-y">Student STEM Identity Ontology (S-STEMIO)</a></li>
       </ol>
       </ul>
       <h3>


### PR DESCRIPTION
Adds three additional ontology-related resources to the BFO Users page:

- The AnIML Ontology
- DN-Hypo-Pipeline Scientific Hypothesis Generation Framework
- Student STEM Identity Ontology (S-STEMIO)